### PR TITLE
Add Business France collection and Discord categories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:

--- a/docs/httpie-collection-businessfrance-vie.json
+++ b/docs/httpie-collection-businessfrance-vie.json
@@ -1,0 +1,185 @@
+{
+  "meta": {
+    "format": "httpie",
+    "version": "1.0.0",
+    "contentType": "collection",
+    "schema": "https://schema.httpie.io/1.0.0.json",
+    "docs": "https://httpie.io/r/help/export-from-httpie",
+    "source": "HTTPie Desktop 2025.2.0"
+  },
+  "entry": {
+    "name": "BusinessFrance - VIE",
+    "icon": {
+      "name": "default",
+      "color": "gray"
+    },
+    "auth": {
+      "type": "none"
+    },
+    "requests": [
+      {
+        "name": "Search",
+        "url": "https://civiweb-api-prd.azurewebsites.net/api/Offers/search",
+        "method": "POST",
+        "headers": [],
+        "queryParams": [],
+        "pathParams": [],
+        "auth": {
+          "type": "inherited"
+        },
+        "body": {
+          "type": "text",
+          "file": {
+            "name": ""
+          },
+          "text": {
+            "value": "{\n    \"limit\": 2,\n    \"skip\": 0,\n    \"query\": \"\",\n    \"missionsTypesIds\": [\n    ],\n    \"activitySectorId\": [],\n    \"missionsDurations\": [],\n    \"gerographicZones\": [],\n    \"countriesIds\": [\"JP\"],\n    \"studiesLevelId\": [],\n    \"companiesSizes\": [],\n    \"specializationsIds\": [],\n    \"entreprisesIds\": [\n    ]\n}",
+            "format": "application/json"
+          },
+          "form": {
+            "isMultipart": false,
+            "fields": []
+          },
+          "graphql": {
+            "query": "",
+            "variables": ""
+          }
+        }
+      },
+      {
+        "name": "findOne",
+        "url": "https://civiweb-api-prd.azurewebsites.net/api/Offers/details/243163",
+        "method": "GET",
+        "headers": [],
+        "queryParams": [],
+        "pathParams": [],
+        "auth": {
+          "type": "inherited"
+        },
+        "body": {
+          "type": "none",
+          "file": {
+            "name": ""
+          },
+          "text": {
+            "value": "",
+            "format": "application/json"
+          },
+          "form": {
+            "isMultipart": false,
+            "fields": []
+          },
+          "graphql": {
+            "query": "",
+            "variables": ""
+          }
+        }
+      },
+      {
+        "name": "List Geographic Zone",
+        "url": "https://civiweb-api-prd.azurewebsites.net/api/Offers/repository/geographic-zones",
+        "method": "GET",
+        "headers": [],
+        "queryParams": [
+          {
+            "name": "page",
+            "value": "1",
+            "enabled": false
+          }
+        ],
+        "pathParams": [],
+        "auth": {
+          "type": "inherited"
+        },
+        "body": {
+          "type": "none",
+          "file": {
+            "name": ""
+          },
+          "text": {
+            "value": "",
+            "format": "application/json"
+          },
+          "form": {
+            "isMultipart": false,
+            "fields": []
+          },
+          "graphql": {
+            "query": "",
+            "variables": ""
+          }
+        }
+      },
+      {
+        "name": "List Countries",
+        "url": "https://civiweb-api-prd.azurewebsites.net/api/Offers/repository/geographic-zones/countries",
+        "method": "POST",
+        "headers": [
+          {
+            "name": "Content-Type",
+            "value": "application/json",
+            "enabled": true
+          }
+        ],
+        "queryParams": [
+          {
+            "name": "page",
+            "value": "1",
+            "enabled": false
+          }
+        ],
+        "pathParams": [],
+        "auth": {
+          "type": "none"
+        },
+        "body": {
+          "type": "text",
+          "file": {
+            "name": ""
+          },
+          "text": {
+            "value": "[1, 2, 3, 4, 5, 6, 7, 8]",
+            "format": "application/json"
+          },
+          "form": {
+            "isMultipart": false,
+            "fields": []
+          },
+          "graphql": {
+            "query": "",
+            "variables": ""
+          }
+        }
+      },
+      {
+        "name": "dataset",
+        "url": "https://civiweb-api-prd.azurewebsites.net/api/Offers/repository/search/dataset",
+        "method": "GET",
+        "headers": [],
+        "queryParams": [],
+        "pathParams": [],
+        "auth": {
+          "type": "inherited"
+        },
+        "body": {
+          "type": "none",
+          "file": {
+            "name": ""
+          },
+          "text": {
+            "value": "",
+            "format": "application/json"
+          },
+          "form": {
+            "isMultipart": false,
+            "fields": []
+          },
+          "graphql": {
+            "query": "",
+            "variables": ""
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/bovie/discord/model.py
+++ b/src/bovie/discord/model.py
@@ -23,8 +23,11 @@ class JobEmbed(Embed):
 
         start: str = isoparse(job.missionStartDate).strftime("%d/%m/%Y")
         end: str = isoparse(job.missionEndDate).strftime("%d/%m/%Y")
-        tags: str = ", ".join([s.specialization_label for s in job.specializations]) if job.specializations else "N/A"
-
+        categories: str = (
+            ", ".join([s.specialization_label for s in job.specializations])
+            if job.specializations
+            else "N/A"
+        )
 
         if job.creationDate:
             posted: str = isoparse(job.creationDate).strftime("%d/%m/%Y")
@@ -47,7 +50,7 @@ class JobEmbed(Embed):
                 name=":globe_with_meridians: Business France",
                 value=f"[Voir offre](https://mon-vie-via.businessfrance.fr/offres/{job.id})",
             ),
-            EmbedField(name="Tags", value=tags),
+            EmbedField(name=":label: Category(ies)", value=categories),
         ]
 
         for f in fields:

--- a/src/bovie/job/models/country.py
+++ b/src/bovie/job/models/country.py
@@ -1,16 +1,15 @@
 import json
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Country(BaseModel):
+    model_config = ConfigDict(validate_by_name=True)
+
     country_id: str = Field(alias="countryId")
     name: str = Field(alias="countryNameEn")
     geographic_zone_id: str = Field(alias="geographicZoneId")
-
-    class Config:
-        validate_by_name = True
 
 """
 POST /api/Offers/repository/geographic-zones/countries HTTP/1.1

--- a/src/bovie/job/models/geozone.py
+++ b/src/bovie/job/models/geozone.py
@@ -1,15 +1,14 @@
 import json
 from typing import List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class GeographicZone(BaseModel):
+    model_config = ConfigDict(validate_by_name=True)
+
     id: str = Field(alias="geographicZoneId")
     name: str = Field(alias="geographicZoneLabelEn")
-
-    class Config:
-        validate_by_name = True
 
 """
 GET /api/Offers/repository/geographic-zones HTTP/1.1

--- a/src/bovie/job/models/specialization.py
+++ b/src/bovie/job/models/specialization.py
@@ -1,17 +1,16 @@
 import json
 from typing import List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Specialization(BaseModel):
+    model_config = ConfigDict(validate_by_name=True)
+
     id: str = Field(alias="specializationId")
     specialization_label: str = Field(alias="specializationLabel")
     specialization_label_en: str = Field(alias="specializationLabelEn")
     parent_id: int | None = Field(alias="specializationParentId")
-
-    class Config:
-        validate_by_name = True
 
 
 """

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -1,0 +1,43 @@
+from bovie.discord.model import JobEmbed
+from bovie.job.models.job import Job
+from bovie.job.models.specialization import Specialization
+
+
+def test_job_embed_displays_job_categories():
+    job = Job.model_construct(
+        id=123,
+        missionTitle="Software Engineer",
+        missionStartDate="2026-06-01T00:00:00",
+        missionEndDate="2027-06-01T00:00:00",
+        creationDate="2026-05-31T00:00:00",
+        missionDuration=12,
+        activitySectorN1="Tech",
+        organizationName="Example Corp",
+        countryName="Canada",
+        cityName="Montreal",
+        indemnite=2500,
+        contactEmail="jobs@example.com",
+        contactName="Jane Doe",
+        specializations=[
+            Specialization(
+                specializationId="24",
+                specializationLabel="SYSTEMES ET LOGICIELS INFORMATIQUES",
+                specializationLabelEn="INFORMATION SYSTEMS",
+                specializationParentId=None,
+            ),
+            Specialization(
+                specializationId="216",
+                specializationLabel="MARKETING - COMMUNICATION",
+                specializationLabelEn="MARKETING COMMUNICATION",
+                specializationParentId=None,
+            ),
+        ],
+    )
+
+    embed = JobEmbed(job).to_dict()
+
+    assert {
+        "inline": True,
+        "name": ":label: Category(ies)",
+        "value": "SYSTEMES ET LOGICIELS INFORMATIQUES, MARKETING - COMMUNICATION",
+    } in embed["fields"]


### PR DESCRIPTION
## Summary
- Add an HTTPie collection for Business France VIE API exploration.
- Display job categories in Discord embeds using the API-provided specialization labels.
- Add a regression test for the Discord category field.

## Test plan
- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run pytest tests/test_discord.py tests`
- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run ruff check src/bovie/discord/model.py tests/test_discord.py`


Made with [Cursor](https://cursor.com)